### PR TITLE
Merge docker-compose and orthanc config changes to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ $ sudo docker-compose up
 Then proceed to test whatever in whatever way.
 The docker reads the a copy of the build from `docker/plugins/`.
 
+If running in WSL, change the volume for Postgres to any location that's native to your linux distribution. Using directories located in ``/mnt`` will cause permission problems. WSL's default directory for anything in Windows are ``/mnt``
+
+For example, change ``./docker/postgres:/var/lib/postgresql/data`` to ``~/docker/postgres:/var/lib/postgresql/data``
+
 ## Contributing
 ### Style Guide
 ```cpp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
-version: '3.1'  # Secrets are only available since this version of Docker Compose
+version: '3.1'
 services:
-  # https://hub.docker.com/_/postgres
-  # Credentials will be passed via secrets later
   postgres:
     image: postgres:latest
     container_name: postgres
@@ -9,26 +7,50 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./docker/postgres:/var/lib/postgresql/data
+      #  WARNING: FOR WSL USE THE FOLLOWING LINE INSTEAD:
+      #- ~/docker/postgres/data:/var/lib/postgresql/data
+      - ./docker/postgres/data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql # Create database for Orthanc
     environment:
       POSTGRES_PASSWORD: example
+    networks:
+      - postgres-network
 
   orthanc:
     image: jodogne/orthanc-plugins:latest
     container_name: orthanc-server
     restart: always
     command: /run/secrets/  # Path to the configuration files (stored as secrets)
+    depends_on:
+      - postgres
     ports:
       - 4242:4242
       - 8042:8042
     volumes:
-      - ./docker/orthanc-db:/var/lib/orthanc/db
-      - ./docker/plugins:/usr/share/orthanc/plugins
+      #  WARNING: FOR WSL USE THE FOLLOWING LINE INSTEAD:
+      #- ~/docker/orthanc/db:/var/lib/orthanc/db
+      - ./docker/orthanc/db:/var/lib/orthanc/db
+      - ./docker/orthanc/plugins:/usr/share/orthanc/plugins
     secrets:
       - orthanc.json
     environment:
       - ORTHANC_NAME=TMI
+    networks:
+      - postgres-network
+
+  adminer:
+    image: adminer:latest
+    container_name: adminer
+    restart: always
+    ports:
+      - 8080:8080
+    networks:
+      - postgres-network
+
+networks:
+  postgres-network:
+    driver: bridge
 
 secrets:
   orthanc.json:
-    file: ./docker/orthanc.json
+    file: ./docker/orthanc/orthanc.json

--- a/docker/orthanc/orthanc.json
+++ b/docker/orthanc/orthanc.json
@@ -7,6 +7,21 @@
   // displayed in Orthanc Explorer and at the URI "/system".
   "Name" : "Orthanc inside Docker",
 
+  "PostgreSQL" : {
+    "EnableIndex" : true,
+    "EnableStorage" : false,
+    "Host" : "postgres",
+    "Port" : 5432,
+    "Database" : "orthanc",
+    "Username" : "postgres",
+    "Password" : "example",
+    "Lock" : false,
+    "EnableSsl" : false,               // New in release 3.0
+    "MaximumConnectionRetries" : 10,   // New in release 3.0
+    "ConnectionRetryInterval" : 5,     // New in release 3.0
+    "IndexConnectionsCount" : 1        // New in release 4.0
+  },
+
   // Path to the directory that holds the heavyweight files (i.e. the
   // raw DICOM instances). Backslashes must be either escaped by
   // doubling them, or replaced by forward slashes "/".

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE orthanc;


### PR DESCRIPTION
Changed the docker-compose and Orthanc config. Now Orthanc should use PostgreSQL as database.
Also changed the structure of the docker directory.
Make sure to run `docker-compose down` before `docker-compose up`
**NOTE:** If you are using WSL make sure to follow the comments in `docker-compose.yml`