### PR TITLE
Adds unit testing for DicomFilter, and a whitelist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
 # target names
 set(PLUGIN_TARGET data-anonymizer)
 set(TEST_TARGET all-tests)
-set(TEST_DP_TARGET dicom-parse-test)
+set(TEST_DP_TARGET dp-main)
 
 # dependencies
 file(GLOB_RECURSE PLUGIN_SOURCES LIST_DIRECTORIES false src/*)

--- a/docker/orthanc/orthanc.json
+++ b/docker/orthanc/orthanc.json
@@ -14,6 +14,9 @@
     "ConnectionRetryInterval": 5,
     "IndexConnectionsCount": 2
   },
+  "Dicom-DateTruncation": {
+    "dateformat": ["YYYY","MM","DD"]
+  },
   "Dicom-Filter": {
     "UseWhitelist": false,
     "tags": [

--- a/src/dicom-filter.cpp
+++ b/src/dicom-filter.cpp
@@ -9,7 +9,7 @@ DicomFilter::DicomFilter(const nlm::json &config) {
         auto log = [](uint64_t &code) {
             char msg_buffer[256] = {0};
             sprintf(msg_buffer, "filter registered tag code: %ld", code);
-            OrthancPluginLogWarning(globals::context, msg_buffer);
+            if(globals::context) OrthancPluginLogWarning(globals::context, msg_buffer);
         };// log the tags registered
         for (const auto &iter: config["Dicom-Filter"]["tags"]) {
             // todo: check that the string has 9 characters; true: do below, false: implement full group filters (eg. "0002,*", "0002")
@@ -29,7 +29,7 @@ DicomFilter::DicomFilter(const nlm::json &config) {
                 log(group_code);
             } else {
                 //bad format, we're gonna fail graciously and let the plugin keep moving
-                OrthancPluginLogWarning(globals::context, "invalid entry in Dicom-Filter tags");
+                if(globals::context) OrthancPluginLogWarning(globals::context, "invalid entry in Dicom-Filter tags");
             }
         }
     } catch (const std::exception &e) {
@@ -84,7 +84,7 @@ simple_buffer DicomFilter::ApplyFilter(DicomFile &file) {
             // compile filtered buffer
             i = 0;
             std::unique_ptr<char[]> buffer(new char[new_size]);
-            OrthancPluginLogWarning(globals::context, "Filter: compile new dicom buffer");
+            if(globals::context) OrthancPluginLogWarning(globals::context, "Filter: compile new dicom buffer");
             for (auto pair: keep_list) {
                 size_t copy_size = pair.second - pair.first;
                 memcpy(buffer.get() + i, ((char*) file.data) + pair.first, copy_size);

--- a/src/plugin-configure.cpp
+++ b/src/plugin-configure.cpp
@@ -12,7 +12,7 @@ int PluginConfigurer::Initialize() {
             fs::create_directories(globals::storage_location);
             fs::permissions(globals::storage_location, globals::dir_permissions);
         } else {
-            OrthancPluginLogError(globals::context, "Configuration json does not contain a StorageDirectory field.");
+            if(globals::context) OrthancPluginLogError(globals::context, "Configuration json does not contain a StorageDirectory field.");
             return -1;
         }
         filter = DicomFilter::ParseConfig(config);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -29,7 +29,7 @@ extern "C" {
                     ORTHANC_PLUGINS_MINIMAL_MINOR_NUMBER,
                     ORTHANC_PLUGINS_MINIMAL_REVISION_NUMBER);
 
-            OrthancPluginLogError(context, info);
+            if(globals::context) OrthancPluginLogError(context, info);
             return -1;
         }
         if(PluginConfigurer::Initialize() != 0){

--- a/src/storage-area.cpp
+++ b/src/storage-area.cpp
@@ -127,7 +127,7 @@ OrthancPluginErrorCode StorageCreateCallback(const char *uuid,
             file.close();
             return OrthancPluginErrorCode_Success;
         }
-        OrthancPluginLogWarning(globals::context, "StorageCreateCallback: but write out appears bad");
+        if(globals::context) OrthancPluginLogWarning(globals::context, "StorageCreateCallback: but write out appears bad");
     }
     return OrthancPluginErrorCode_FileStorageCannotWrite;
 }
@@ -145,7 +145,7 @@ OrthancPluginErrorCode StorageReadWholeCallback(OrthancPluginMemoryBuffer64 *tar
             file.close();
             return OrthancPluginErrorCode_Success;
         }
-        OrthancPluginLogWarning(globals::context, "StorageReadWholeCallback: opened file, but couldn't read it");
+        if(globals::context) OrthancPluginLogWarning(globals::context, "StorageReadWholeCallback: opened file, but couldn't read it");
         return OrthancPluginErrorCode_StorageAreaPlugin;
     }
     return OrthancPluginErrorCode_InexistentFile;

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -1,0 +1,73 @@
+#include <filesystem>
+#include <functional>
+#include <iostream>
+namespace fs = std::filesystem;
+
+fs::path GetProjRoot() {
+    // linux only line to acquire the path of the executable
+    fs::path exec_path(fs::canonical("/proc/self/exe"));
+    if (exec_path.empty()) {
+        // if we're on windows try ./samples as the relative path
+        return fs::path("."); // probably won't work
+    } else {
+        // if we're on linux, then get the directory the executable is stored in
+        exec_path = exec_path.parent_path();
+        // if that directory is the build/bin, then our relative path is ../../samples
+        if (exec_path.string().find("build/debug/bin") != std::string::npos) {
+            return fs::canonical(exec_path.string() + "/../../../");
+        }
+    }
+    return fs::canonical(exec_path.string() + "/../../");
+}
+
+void TestWithDicomFiles(std::function<void(const fs::path&)> test){
+    auto samples = fs::path(GetProjRoot().string() + "/samples/");
+    // recurse sample directory, parse every file as a dicom
+    std::cout << "reading from: " << samples << std::endl;
+    fs::recursive_directory_iterator recursive_iter(samples);
+    for(auto &entry : recursive_iter){
+        auto path = entry.path();
+        if(!fs::is_directory(path)) {
+            if (path.extension().string() == ".DCM") {
+                test(path);
+            }
+        }
+    }
+}
+
+#include <random>
+#include <sstream>
+
+namespace uuid {
+    static std::random_device              rd;
+    static std::mt19937                    gen(rd());
+    static std::uniform_int_distribution<> dis(0, 15);
+    static std::uniform_int_distribution<> dis2(8, 11);
+
+    std::string generate_uuid_v4() {
+        std::stringstream ss;
+        int i;
+        ss << std::hex;
+        for (i = 0; i < 8; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        for (i = 0; i < 4; i++) {
+            ss << dis(gen);
+        }
+        ss << "-4";
+        for (i = 0; i < 3; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        ss << dis2(gen);
+        for (i = 0; i < 3; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        for (i = 0; i < 12; i++) {
+            ss << dis(gen);
+        };
+        return ss.str();
+    }
+}

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,0 +1,6 @@
+#pragma once
+extern fs::path GetProjRoot();
+extern void TestWithDicomFiles(std::function<void(const fs::path&)> test);
+namespace uuid {
+    extern std::string generate_uuid_v4();
+}

--- a/tests/tests-dicom-parse.cpp
+++ b/tests/tests-dicom-parse.cpp
@@ -4,48 +4,25 @@
 #include <filesystem>
 #include <functional>
 #include <fstream>
+#include "common.h"
 
 namespace fs = std::filesystem;
 
-TEST(dicom_parsing, dicom_parse) {
-    // linux only line to acquire the path of the executable
-    fs::path exec_path(fs::canonical("/proc/self/exe"));
-    fs::path samples;
-    if(exec_path.empty()) {
-        // if we're on windows try ./samples as the relative path
-        samples = fs::path("./samples/"); // probably won't work
-    } else {
-        // if we're on linux, then get the directory the executable is stored in
-        exec_path = exec_path.parent_path();
-        // if that directory is the build/bin, then our relative path is ../../samples
-        if(exec_path.string().find("build/debug/bin") != std::string::npos){
-            exec_path = fs::canonical(exec_path.string() + "/../../../");
-        } else if(exec_path.string().find("build/bin") != std::string::npos){
-            exec_path = fs::canonical(exec_path.string() + "/../../");
-        }
-        samples = fs::path(exec_path.string() + "/samples/");
-    }
-    // ASSERT_TRUE won't compile in regular functions, so we make a lambda to pass it to other functions
 
-    // recurse sample directory, parse every file as a dicom
-    std::cout << "reading from: " << samples << std::endl;
-    fs::recursive_directory_iterator recursive_iter(samples);
-    for(auto &entry : recursive_iter){
-        auto &path = entry.path();
-        if(!fs::is_directory(path)){
-            if(path.extension().string() == ".DCM"){
-                std::cout << "Parse " << path << std::endl;
-                auto size = fs::file_size(path);
-                char* buffer = new char[size];
-                std::ifstream file(path);
-                ASSERT_TRUE(file.is_open());
-                file.read(buffer,size);
-                file.close();
-                DicomFile dicom(buffer,size);
-                ASSERT_TRUE(dicom.IsValid());
-                delete[] buffer;
-            }
-        }
-    }
+TEST(dicom_parsing, dicom_parse) {
+    std::function<void(const fs::path&)> test = [](const fs::path &path){
+        std::cout << "Parse " << path << std::endl;
+        auto size = fs::file_size(path);
+        char* buffer = new char[size];
+        std::ifstream file(path);
+        ASSERT_TRUE(file.is_open());
+        file.read(buffer,size);
+        file.close();
+        DicomFile dicom(buffer,size);
+        ASSERT_TRUE(dicom.IsValid());
+        delete[] buffer;
+    };
+    TestWithDicomFiles(test);
+    std::cout << "Test Complete." << std::endl;
 }
 

--- a/tests/tests-storage.cpp
+++ b/tests/tests-storage.cpp
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+#include <storage-area.h>
+#include <dicom-filter.h>
+#include <iostream>
+#include <fstream>
+#include "common.h"
+
+extern OrthancPluginErrorCode WriteDicomFile(DicomFile dicom, const char *uuid);
+
+TEST(storing, store_filtered) {
+    fs::path config_path(GetProjRoot().string() + "/docker/orthanc/orthanc.json");
+    nlm::json config;
+    std::cout << "Loading config.." << std::endl;
+    if(fs::exists(config_path)) {
+        std::ifstream file(config_path);
+        if(file.is_open()) {
+            size_t size = fs::file_size(config_path);
+            ASSERT_TRUE(size != 0);
+            char* buffer = new char[size];
+            file.read(buffer,size);
+            std::cout << " parsing config" << std::endl;
+            config = nlm::json::parse(buffer);
+            delete[] buffer;
+            std::cout << " parsed" << std::endl;
+        } else {
+            ASSERT_TRUE(false);
+        }
+    } else {
+        ASSERT_TRUE(false);
+    }
+    std::cout << "Configuring DicomFilter.." << std::endl;
+    DicomFilter filter = DicomFilter::ParseConfig(config);
+    std::cout << " configured" << std::endl;
+    auto test = [&](const fs::path &path){
+        std::cout << "Loading " << path << std::endl;
+        auto size = fs::file_size(path);
+        char* buffer = new char[size];
+        std::ifstream file(path);
+        ASSERT_TRUE(file.is_open());
+        file.read(buffer,size);
+        file.close();
+        ASSERT_TRUE(file.good());
+        DicomFile dicom(buffer, size);
+        auto filtered = filter.ApplyFilter(dicom);
+        delete[] buffer;
+
+        ASSERT_TRUE(fs::exists(path.parent_path().string()));
+        fs::path output_path(path.parent_path().string() + "/filtered.dcm");
+        std::ofstream output(output_path);
+        output.write(std::get<0>(filtered).get(),std::get<1>(filtered));
+        output.close();
+        ASSERT_TRUE(output.good());
+        ASSERT_TRUE(fs::file_size(output_path) <= size);
+        fs::remove(output_path);
+    };
+    TestWithDicomFiles(test);
+    std::cout << "Test Complete." << std::endl;
+}

--- a/tests/tests-storage.cpp
+++ b/tests/tests-storage.cpp
@@ -32,9 +32,9 @@ TEST(storing, store_filtered) {
     DicomFilter filter = DicomFilter::ParseConfig(config);
     std::cout << " configured" << std::endl;
     auto test = [&](const fs::path &path){
-        std::cout << "Loading " << path << std::endl;
         auto size = fs::file_size(path);
         char* buffer = new char[size];
+        std::cout << "Loading " << path << std::endl;
         std::ifstream file(path);
         ASSERT_TRUE(file.is_open());
         file.read(buffer,size);


### PR DESCRIPTION
I accidentally branched this from `feat-truncation`

The unit test basically implements a simple size check to ensure the filtered version has less content than the non. Later this can be improved, possibly. Not sure how, but surely..

edit: also the all-tests unit test fails with a SIGABRT signal.. but they run fine individually.. so I think the file io tests are conflicting with each other in parallel execution.. I don't know what else it could be