### PR TITLE
Added a second Orthanc instance acting as a modality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ fabric.properties
 
 #Docker
 docker/orthanc/db/
+docker/orthanc/storage/
 docker/postgres/data/
 
 #submodules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     image: brianzhouzc/orthanc-tmi-plugins:latest
     entrypoint: ['Orthanc']#, '--verbose']
     container_name: orthanc-server
+    restart: always
     command: /run/secrets/  # Path to the configuration files (stored as secrets)
     depends_on:
       postgres:
@@ -45,6 +46,23 @@ services:
     networks:
       - postgres-network
 
+  orthanc_client:
+    image: jodogne/orthanc
+    container_name: orthanc-client
+    restart: always
+    command: /run/secrets/  # Path to the configuration files (stored as secrets)
+    depends_on:
+      - orthanc
+    ports:
+      - 4243:4243
+      - 8043:8043
+    secrets:
+      - orthanc_client.json
+    environment:
+      - ORTHANC_NAME=ORTHANC_CLIENT
+    networks:
+      - postgres-network
+
   adminer:
     image: adminer:latest
     container_name: adminer
@@ -61,3 +79,5 @@ networks:
 secrets:
   orthanc.json:
     file: ./docker/orthanc/orthanc.json
+  orthanc_client.json:
+    file: ./docker/orthanc/orthanc_client.json

--- a/docker/orthanc/orthanc_client.json
+++ b/docker/orthanc/orthanc_client.json
@@ -1,30 +1,5 @@
 {
   "Name": "Orthanc inside Docker",
-  "PostgreSQL": {
-    "EnableIndex": true,
-    "EnableStorage": false,
-    "Host": "postgres",
-    "Port": 5432,
-    "Database": "orthanc",
-    "Username": "postgres",
-    "Password": "example",
-    "Lock": false,
-    "EnableSsl": false,
-    "MaximumConnectionRetries": 10,
-    "ConnectionRetryInterval": 5,
-    "IndexConnectionsCount": 2
-  },
-  "Dicom-DateTruncation": {
-    "dateformat": ["YYYY","04","10"]
-  },
-  "Dicom-Filter": {
-    "blacklist": [
-      "0010"
-    ],
-    "whitelist": [
-      "0010,0030"
-    ]
-  },
   "StorageDirectory": "/var/lib/orthanc/dicom",
   "StorageSettings": {
     "LinkDOB": true,
@@ -43,16 +18,16 @@
   "ConcurrentJobs": 2,
   "HttpServerEnabled": true,
   "OrthancExplorerEnabled": true,
-  "HttpPort": 8042,
+  "HttpPort": 8043,
   "HttpDescribeErrors": true,
   "HttpCompressionEnabled": true,
   "WebDavEnabled": true,
   "WebDavDeleteAllowed": false,
   "WebDavUploadAllowed": true,
   "DicomServerEnabled": true,
-  "DicomAet": "ORTHANC",
+  "DicomAet": "ORTHANC_CLIENT",
   "DicomCheckCalledAet": false,
-  "DicomPort": 4242,
+  "DicomPort": 4243,
   "DefaultEncoding": "Latin1",
   "AcceptedTransferSyntaxes": [
     "1.2.840.10008.1.*"
@@ -76,7 +51,7 @@
   "DicomAlwaysAllowMove": false,
   "DicomCheckModalityHost": false,
   "DicomModalities": {
-    "orthanc-client" : [ "ORTHANC_CLIENT", "orthanc-client", 4243 ]
+    "orthanc" : [ "ORTHANC", "orthanc", 4242 ]
   },
   "DicomModalitiesInDatabase": false,
   "DicomEchoChecksFind": false,


### PR DESCRIPTION
As title. The second Orthanc instance has port 8043 and can be accessed via `localhost:8043`.

I tested `C-Echo`, `C-Store`, `C-Find`, `C-Get` and they are all working properly. The only thing I didn't test is `C-Move`.

When sending DICOM images via C-Store, the Orthanc server is able to correctly receive the file and the plugin is able to anonymize the file:
```bash
orthanc-server  | W0204 21:08:54.218105 PluginsManager.cpp:168] DicomFile: parsing dicom data
orthanc-server  | W0204 21:08:54.218847 PluginsManager.cpp:168] buffer size = 2615330, read head idx = 2615330
orthanc-server  | W0204 21:08:54.218916 PluginsManager.cpp:168] Filtering DICOM file
orthanc-server  | W0204 21:08:54.218921 PluginsManager.cpp:168] ApplyFilter: !ready
orthanc-server  | W0204 21:08:54.219003 PluginsManager.cpp:168] Filter: compile new dicom buffer
orthanc-server  | W0204 21:08:54.219027 PluginsManager.cpp:168] i: 0, range.1: 0, range.2: 2204, copy_size: 2204
orthanc-server  | W0204 21:08:54.219032 PluginsManager.cpp:168] i: 2204, range.1: 2242, range.2: 2250, copy_size: 8
orthanc-server  | W0204 21:08:54.224121 PluginsManager.cpp:168] i: 2212, range.1: 2260, range.2: 2615330, copy_size: 2613070
orthanc-server  | W0204 21:08:54.224428 PluginsManager.cpp:168] ApplyFilter: new buffer complete
orthanc-server  | W0204 21:08:54.224463 PluginsManager.cpp:168] Filtering complete
orthanc-server  | W0204 21:08:54.260995 PluginsManager.cpp:168] WriteDicomFile: permissions set
orthanc-server  | W0204 21:08:54.261040 PluginsManager.cpp:168] WriteDicomFile: success
orthanc-server  | W0204 21:08:54.280311 PluginsManager.cpp:168] OnStored Instance Id: 79d57ad0-60beeeea-861b5d8f-f222e427-309b9a9f
orthanc-server  | W0204 21:08:54.284143 PluginsManager.cpp:168] Checksum: MD5 = 8c04e5404444a4b5c78420fb1bac1f84, size = 2615330
```
Hope this is useful for future testings.